### PR TITLE
Update package.json script for snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "ci:test": "pnpm ci:build && vitest --reporter=github-actions --reporter=basic",
       "ci:version": "pnpm changeset version",
       "ci:publish": "pnpm changeset publish",
-      "ci:snapshot": "pnpx pkg-pr-new publish --pnpm './packages/*'"
+      "ci:snapshot": "pnpx pkg-pr-new publish --compact --pnpm './packages/*'"
     },
     "dependencies": {
         "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change modifies the `ci:snapshot` script to include the `--compact` flag when running the `pkg-pr-new publish` command.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Updated the `ci:snapshot` script to use the `--compact` flag for the `pkg-pr-new publish` command.