### PR TITLE
Refactor CI workflows

### DIFF
--- a/.github/workflows/ci-first-contributor.yml
+++ b/.github/workflows/ci-first-contributor.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: First Interaction Check
-        uses: zephyrproject-rtos/action-first-interaction@7e6446f8439d8b4399169880c36a3a12b5747699
+        uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
-          issue-message: >
+          issue-message: |
             Hi @${{ github.event.issue.user.login }} 👋
 
             Welcome to the StudioCMS project eco-system! We're excited to have you here. Thanks for opening your first issue! 🎉
@@ -38,8 +38,8 @@ jobs:
 
             - The StudioCMS Team
 
-          pr-opened-message: >
-            Hello @${{ github.event.pull_request.user.login }}, and thank you for opening your first pull request to the StudioCMS Ecosystem! 🎉
+          pr-message: |
+            Hello @${{ github.event.pull_request.user.login }}, and thank you for opening your first pull request to this project of the StudioCMS Ecosystem! 🎉
 
             Please make sure to review the project's [Contributing Guide](https://github.com/withstudiocms/.github/blob/main/CONTRIBUTING.md) to ensure your pull request meets our quality standards.
 

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -17,7 +17,15 @@ permissions:
   id-token: write
 
 jobs:
+    mergebot:
+      name: Mergebot
+      if: ${{ github.repository_owner == 'withstudiocms' && github.event_name == 'push' && github.event.commits[0].message != '[ci] lint' && github.event.commits[0].author.username != 'dependabot[bot]' }}
+      uses: withstudiocms/automations/.github/workflows/mergebot.yml@main
+      secrets:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}
+
     format:
+      name: Format Code
       runs-on: ubuntu-latest
       env:
         NODE_OPTIONS: "--max_old_space_size=4096"
@@ -42,14 +50,9 @@ jobs:
             commit_user_name: studiocms-no-reply
             commit_user_email: no-reply@studiocms.dev
             commit_author: StudioCMS <no-reply@studiocms.dev>
-            
-    mergebot:
-      if: ${{ github.repository_owner == 'withstudiocms' && github.event_name == 'push' && github.event.commits[0].message != '[ci] lint' && github.event.commits[0].author.username != 'dependabot[bot]' }}
-      uses: withstudiocms/automations/.github/workflows/mergebot.yml@main
-      secrets:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}
 
     changeset-release:
+      if: ${{ github.repository_owner == 'withstudiocms' }}
       name: Changeset Release
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -15,7 +15,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows to improve CI processes and streamline messages for contributors. The most important changes include updating action versions, modifying messages for first interactions and pull requests, adding a mergebot job, and removing the closed event trigger from the testing workflow.

Updates to action versions and messages:

* [`.github/workflows/ci-first-contributor.yml`](diffhunk://#diff-2a5f5bc5da2d8a62d8fbaa93f5a7dec135b0ec8f65976ef30c760a046f510146L18-R21): Updated the `first-interaction` action to use `actions/first-interaction@v1` and modified the issue and pull request messages to use a more concise format. [[1]](diffhunk://#diff-2a5f5bc5da2d8a62d8fbaa93f5a7dec135b0ec8f65976ef30c760a046f510146L18-R21) [[2]](diffhunk://#diff-2a5f5bc5da2d8a62d8fbaa93f5a7dec135b0ec8f65976ef30c760a046f510146L41-R42)

Enhancements to CI workflows:

* [`.github/workflows/ci-push-main.yml`](diffhunk://#diff-33ba2fe1c42a4f2840fedd78cc4f69a10dc97c7ea276965db40186dd2795b8f1R20-R28): Added a `mergebot` job to automate merges under specific conditions and moved the `mergebot` job to an earlier position in the file. [[1]](diffhunk://#diff-33ba2fe1c42a4f2840fedd78cc4f69a10dc97c7ea276965db40186dd2795b8f1R20-R28) [[2]](diffhunk://#diff-33ba2fe1c42a4f2840fedd78cc4f69a10dc97c7ea276965db40186dd2795b8f1L46-R55)
* [`.github/workflows/ci-testing.yml`](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL18): Removed the `closed` event trigger from the `on` section to prevent unnecessary workflow runs when issues are closed.