### PR TITLE
re-enabled --compact now that packages are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "ci:test": "pnpm ci:build && vitest --reporter=github-actions --reporter=basic",
       "ci:version": "pnpm changeset version",
       "ci:publish": "pnpm changeset publish",
-      "ci:snapshot": "pnpx pkg-pr-new publish --pnpm './packages/*'"
+      "ci:snapshot": "pnpx pkg-pr-new publish --compact --pnpm './packages/*'"
     },
     "dependencies": {
         "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the `ci:snapshot` script to include the `--compact` flag for the `pnpx pkg-pr-new publish` command.