### PR TITLE
Update ci-renovate.yml

### DIFF
--- a/.github/workflows/ci-renovate.yml
+++ b/.github/workflows/ci-renovate.yml
@@ -3,6 +3,8 @@ name: Add changeset to Renovate updates
 on:
   pull_request_target:
     types: [opened, synchronize, labeled]
+    paths:
+      - 'packages/**'
 
 jobs:
   renovate:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci-renovate.yml` file. The change adds a `paths` filter to the `pull_request_target` event to only trigger the workflow for changes in the `packages` directory.

* [`.github/workflows/ci-renovate.yml`](diffhunk://#diff-541e73f76dfc7f14f49d736f365a707a685135abae37b14168a65c8ea8fa3309R6-R7): Added `paths` filter to `pull_request_target` event to trigger workflow only for changes in the `packages` directory.